### PR TITLE
Improve postInstall script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0']
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Fix autocrlf on Windows

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -19,7 +19,6 @@ $config = new Susina\CodingStandard\Config();
 $config->getFinder()
     ->in(__DIR__ . "/src")
     ->in(__DIR__ . "/tests")
-    ->in(__DIR__ . "/script")
 ;
 
 return $config;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0] - 2121-07-23
+## [2.2.0] - 2021-07-26
+### Changed
+-  Remove unsupported PHP 7.2 version
+-  Add PHP 8.1 to ci
+-  Move `script` directory under `src`
+-  Adjust `postInstall` Compose script to:
+    -  update the configuration file, if it finds a deprecated `php_cs.dist`
+    -  delete the deprecated `php_cs.cache` cache file.
+
+## [2.1.0] - 2021-07-23
 ### Changed
 -  Bump `php-cs-fixer` to 3.0 version
 -  Adjust deprecations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.2.0] - 2021-07-26
 ### Changed
 -  Remove unsupported PHP 7.2 version
--  Add PHP 8.1 to ci
 -  Move `script` directory under `src`
 -  Adjust `postInstall` Compose script to:
     -  update the configuration file, if it finds a deprecated `php_cs.dist`

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "Susina\\CodingStandard\\": "src/",
-            "Susina\\CodingStandard\\Script\\": "script/"
+            "Susina\\CodingStandard\\": "src/"
         }
     },
     "autoload-dev": {
@@ -28,12 +27,12 @@
         }
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.3",
         "ext-json": "*",
         "friendsofphp/php-cs-fixer": "^3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^9",
         "mikey179/vfsstream": "^1.6",
         "composer/composer": "^2.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,26 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        bootstrap="vendor/autoload.php"
+        colors="true"
 >
-
+  <coverage>
+    <include>
+      <directory>./src</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="Coding Standard Test Suite">
       <directory>./tests</directory>
     </testsuite>
   </testsuites>
-
-  <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
-      <directory>./src</directory>
-    </whitelist>
-  </filter>
-
 </phpunit>

--- a/src/Script/ComposerScripts.php
+++ b/src/Script/ComposerScripts.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 /*
- * Copyright 2020 Cristiano Cinotti
+ * Copyright 2020-2021 Cristiano Cinotti
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,16 +23,22 @@ class ComposerScripts
 {
     public static function postInstall(Event $event)
     {
-        $basePath = $event->getArguments()['basePath'] ?? __DIR__ . '/..';
+        $basePath = $event->getArguments()['basePath'] ?? __DIR__ . '/../..';
 
         static::createStub($basePath);
         static::addScripts($basePath);
         static::updateGitignore($basePath);
+        static::removeDeprecatedCache($basePath);
     }
 
     private static function createStub(string $basePath): void
     {
         $stubFile = "$basePath/.php-cs-fixer.php";
+        $deprecated = "$basePath/.php_cs.dist";
+
+        if (file_exists($deprecated)) {
+            rename($deprecated, $stubFile);
+        }
 
         if (!file_exists($stubFile)) {
             $content = '<?php declare(strict_types=1);
@@ -75,6 +81,13 @@ return $config;
             if (false === strpos($content, '.php-cs-fixer.cache') && false === strpos($content, '*.cache')) {
                 file_put_contents($gitignoreFile, "$content\n.php-cs-fixer.cache\n");
             }
+        }
+    }
+
+    private static function removeDeprecatedCache(string $basePath): void
+    {
+        if (file_exists("$basePath/.php_cs.cache")) {
+            unlink("$basePath/.php_cs.cache");
         }
     }
 }


### PR DESCRIPTION
-  Remove unsupported PHP 7.2 version
-  Add PHP 8.1 to ci
-  Move `script` directory under `src`
-  Adjust `postInstall` Compose script to:
   -  update the configuration file, if it finds a deprecated `php_cs.dist`
   -  delete the deprecated `php_cs.cache` cache file.

This PR closes #3 